### PR TITLE
Updated the proxies snippet as the config was missing for the AzureId…

### DIFF
--- a/src/snippets/custom_clients.py
+++ b/src/snippets/custom_clients.py
@@ -56,7 +56,7 @@ class CustomClients:
         # of the credential classes from azure.identity
         credential = DeviceCodeCredential(
             "client_id", tenant_id = "tenant_id", proxies = proxies)
-        
+
         # Create an authentication provider
         # credential is one of the credential classes from azure.identity
         # scopes is an array of permission scope strings

--- a/src/snippets/custom_clients.py
+++ b/src/snippets/custom_clients.py
@@ -45,20 +45,28 @@ class CustomClients:
     def create_with_proxy(
         credential: TokenCredential, scopes: List[str]) -> GraphServiceClient:
         # <ProxySnippet>
+        # Proxy URLs
+        proxies = {
+            'http': 'http://proxy-url',
+            'https': 'http://proxy-url',
+        }
+        
         # Create an authentication provider
         # credential is one of the credential classes from azure.identity
         # scopes is an array of permission scope strings
-        auth_provider = AzureIdentityAuthenticationProvider(credential, scopes=scopes)
+        # proxies is an optional dict containing proxies configuration in requests format
+        auth_provider = AzureIdentityAuthenticationProvider(credential, scopes=scopes, proxies=proxies)
 
-        # Proxy URLs
-        proxies = {
-            'http://': 'http://proxy-url',
-            'https://': 'http://proxy-url',
+        # HTTPX Proxy URLs
+        httpx_proxies = {
+            'http://': proxies['http'],
+            'https://': proxies['https'],
         }
 
         # Create a custom HTTP client with the proxies
         # httpx.AsyncClient
-        http_client = AsyncClient(proxies=proxies) # type: ignore
+        # proxies is an optional dict containing proxies configuration in httpx format
+        http_client = AsyncClient(proxies=httpx_proxies) # type: ignore
 
         # Apply the default Graph middleware to the HTTP client
         http_client = GraphClientFactory.create_with_default_middleware(client=http_client)

--- a/src/snippets/custom_clients.py
+++ b/src/snippets/custom_clients.py
@@ -3,6 +3,7 @@
 
 from typing import List
 from azure.core.credentials import TokenCredential
+from azure.identity import DeviceCodeCredential
 from msgraph import GraphServiceClient, GraphRequestAdapter
 from msgraph_core import GraphClientFactory
 from kiota_authentication_azure.azure_identity_authentication_provider import (
@@ -43,19 +44,24 @@ class CustomClients:
 
     @staticmethod
     def create_with_proxy(
-        credential: TokenCredential, scopes: List[str]) -> GraphServiceClient:
+        scopes: List[str]) -> GraphServiceClient:
         # <ProxySnippet>
         # Proxy URLs
         proxies = {
             'http': 'http://proxy-url',
             'https': 'http://proxy-url',
         }
+
+        # Create a token credential with the proxies. It can be any
+        # of the credential classes from azure.identity
+        credential = DeviceCodeCredential(
+            "client_id", tenant_id = "tenant_id", proxies = proxies)
         
         # Create an authentication provider
         # credential is one of the credential classes from azure.identity
         # scopes is an array of permission scope strings
         # proxies is an optional dict containing proxies configuration in requests format
-        auth_provider = AzureIdentityAuthenticationProvider(credential, scopes=scopes, proxies=proxies)
+        auth_provider = AzureIdentityAuthenticationProvider(credential, scopes=scopes)
 
         # HTTPX Proxy URLs
         httpx_proxies = {


### PR DESCRIPTION
…entityAuthenticationProvider

Updated the proxies snippet as the config was missing for the AzureIdentityAuthenticationProvider, also the proxy config differs between the AzureIdentityAuthenticationProvider and the httpx AsyncClient as the first one uses the requests libary and the second one use httpx so the keys are different.  Also if you only pass the proxy config to the AsyncClient, the authentication will fail as it doesn't have the proxy config as it uses another client internally.